### PR TITLE
chore: Adds CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
 *                       @primer-io/acceptance-mobile-android
-
-.github/CODEOWNERS      @primer-io/checkout-pci-reviewers
-.github/workflows        @primer-io/checkout-pci-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+*                       @primer-io/acceptance-mobile-android
+
+.github/CODEOWNERS      @primer-io/checkout-pci-reviewers
+.github/workflows        @primer-io/checkout-pci-reviewers


### PR DESCRIPTION
Adds acceptance-mobile-ios as a codeowner and adds default codeowners

https://primerapi.atlassian.net/browse/ACC-3476